### PR TITLE
Update readme to remove reference to FarRenderTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,4 @@ My end goal is to achieve the following:
 - be compatible with [Cubic Chunks](https://github.com/OpenCubicChunks/CubicChunks)
 - be as compatible as reasonably possible with other mods
 
-I have exactly zero concern with doing stuff that is unsafe: for instance, [the client-side render tree](https://github.com/PorkStudios/FarPlaneTwo/blob/master/src/main/java/net/daporkchop/fp2/mode/common/client/FarRenderTree.java), which the renderer traverses when deciding which tiles to render each frame, is implemented entirely using off-heap memory.
-
 At some point (once the internals of the mod are more polished) I'll probably write up a big section here describing exactly how a lot of the stuff works.


### PR DESCRIPTION
In 33cf222476ca65f803dceab146582856b7582c53 FarRenderTree was removed, making this section of the readme point to a 404.

Closes #168 
